### PR TITLE
chore: change `fabric` to `fabric-api`

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,7 +18,7 @@
   },
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": ">=${minecraft_version}"
   }
 }


### PR DESCRIPTION
Fabric removed the `fabric` mod id from the Fabric api via. https://github.com/FabricMC/fabric-api/pull/5055 making it impossible to use the hypixel mod api in 26.1 without applying workarounds.